### PR TITLE
Improve Makefile and remove unused variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,26 @@
+CC ?= clang
+RM	= rm -f
+
+CFLAGS += -ansi -g -Wall -Wextra -Werror -Wno-unused-function -Isrc/ \
+			 `pkg-config --cflags guile-2.2`
+LDFLAGS += -lreadline `pkg-config --libs guile-2.2`
+
+
 TARGET ?= turtle
 SRC_DIRS ?= ./src
-CC = clang
+
 SRCS := $(shell find $(SRC_DIRS) -name *.c)
 OBJS := $(addsuffix .o,$(basename $(SRCS)))
-CFLAGS ?= -ansi  -g -Wall -Wextra -Wno-unused-result -Werror -Wno-unused-function -Isrc/ `pkg-config --cflags guile-2.2`
-LDLIBS = -lreadline `pkg-config --libs guile-2.2`
+
+all: $(TARGET)
+
 %.o: %.c
 	@echo [ CC ] $<
 	@$(CC) $(CFLAGS) -c $< -o $@
-$(TARGET): $(OBJS)
 
+$(TARGET): $(OBJS)
 	@echo [ BIN ] $<
-	@$(CC) $(LDFLAGS) $(OBJS) -o $@ $(LOADLIBS) $(LDLIBS)
+	@$(CC) -o $@ $^ $(LDFLAGS)
 
 install:
 	@cp .turtlerc.scm ~
@@ -19,11 +28,14 @@ install:
 	@mkdir -p ~/.local/share/turtle
 	@cp -r lib/ ~/.local/share/turtle
 	@echo "Installed turtle to ~/.local/bin"
+
 uninstall:
 	rm -rf ~/.turtle_history ~/.turtlerc.scm 
 	rm -rf ~/.local/share/turtle ~/.local/bin/turtle
 
-.PHONY: clean
 clean:
-	$(RM) $(TARGET) $(OBJS) 
+	$(RM) $(TARGET) $(OBJS)
 
+re: clean all
+
+.PHONY: all install uninstall clean re

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -68,7 +68,7 @@ int spawn_command(char *command)
 
     command_array = parse_string(buffer);
 
-    pid_t pid, wait_pid;
+    pid_t pid;
 
     int status = 0;
     pid = fork();
@@ -96,7 +96,7 @@ int spawn_command(char *command)
     {
         do
         {
-            wait_pid = waitpid(pid, &status, WUNTRACED);
+            waitpid(pid, &status, WUNTRACED);
         } while (!WIFEXITED(status) && !WIFSIGNALED(status));
     }
 


### PR DESCRIPTION
Some explaination:

* `?=` doesn't not overwrite value (eg: `CC ?= clang` if CC is not set then it will be set to clang)
* `+=` append (eg: in case of  `CFLAGS += "-Wall"` and `$ CFLAGS="-Werror" make`  CFLAGS will be set to "-Werror -Wall")
* rename LDLIBS to LDFLAGS
* add re rule (basicly clean and rebuild)
* mark uninstall install all re as [.PHONY](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html)
* remove `wait_pid` since unused